### PR TITLE
fix: separate column projections, and stop a full ctx queue killing the runner

### DIFF
--- a/src/crane/core/runners/multi_process_runner.py
+++ b/src/crane/core/runners/multi_process_runner.py
@@ -17,11 +17,12 @@ from __future__ import annotations
 import logging
 import multiprocessing as mp
 import multiprocessing.connection  # noqa: F401
+import time
 import traceback
 from dataclasses import dataclass
 from enum import Enum
 from functools import partial
-from queue import Empty
+from queue import Empty, Full
 from typing import Any, Callable, Iterable, TypeAlias
 
 import dill
@@ -33,6 +34,7 @@ from datasets.iterable_dataset import (
     FormattingConfig,
     MappedExamplesIterable,
     RebatchedArrowExamplesIterable,
+    SelectColumnsIterable,
     _BaseExamplesIterable,
     identity_func,
 )
@@ -53,6 +55,13 @@ from .base import BaseRunner, WorkerProcessingStage, WorkerRole
 # shorthands and helper type aliases
 Stages: TypeAlias = WorkerProcessingStage
 
+# How long to keep trying to hand a new context to a worker before giving up on that
+# particular context. The race this absorbs is the queue feeder thread being momentarily
+# behind, which resolves in milliseconds, so keep it short: contexts are also sent from
+# the balancer's hot path and a long block there would stall coordination.
+_CTX_SEND_TIMEOUT: float = 1.0
+_CTX_SEND_RETRY_INTERVAL: float = 0.01
+
 # The lazy processing steps that `_prepare_dataset` separates from the data source.
 # `FormattedExamplesIterable` was introduced in newer `datasets` releases (it is inserted
 # into the iterable chain by `.map`); guard the import so crane keeps working on versions
@@ -68,6 +77,42 @@ try:
     _SEPARABLE_EX_ITERABLES += (_FormattedExamplesIterable,)
 except ImportError:
     pass
+
+# Column projections are separable, but only conditionally. `.map(remove_columns=...)`
+# inserts a `SelectColumnsIterable` mid-chain, and if the walk stops there every step
+# below it stays with the data source: those steps then run in the producers, and
+# sharding a source that still contains an arrow-formatted map fails outright with
+# "doesn't implement iter_arrow()".
+#
+# Separating a projection unconditionally is not right either. One sitting directly on
+# the source is pure projection, and keeping it in the producer means fewer columns
+# travel through the queue. So a projection is separated only when there is something
+# separable beneath it, which is exactly the case where leaving it behind would strand
+# real work in the producers.
+_PROJECTION_EX_ITERABLES: tuple[type, ...] = (SelectColumnsIterable,)
+
+
+def _has_separable_below(ex_iterable: _BaseExamplesIterable) -> bool:
+    """Whether any step beneath `ex_iterable` is itself separable processing."""
+    node = getattr(ex_iterable, "ex_iterable", None)
+    while node is not None:
+        if isinstance(node, _SEPARABLE_EX_ITERABLES):
+            return True
+        node = getattr(node, "ex_iterable", None)
+    return False
+
+
+def _is_separable(ex_iterable: _BaseExamplesIterable) -> bool:
+    """Whether a step should be moved off the data source and into the workers.
+
+    Processing steps always are. A column projection is only worth separating when real
+    work sits beneath it; see `_PROJECTION_EX_ITERABLES`.
+    """
+    if isinstance(ex_iterable, _SEPARABLE_EX_ITERABLES):
+        return True
+    if isinstance(ex_iterable, _PROJECTION_EX_ITERABLES):
+        return _has_separable_below(ex_iterable)
+    return False
 
 
 @dataclass
@@ -269,15 +314,9 @@ class Worker(mp.Process):
         while self._recv_ctx_resp_conn.poll():
             self._recv_ctx_resp_conn.recv()
 
-        try:
-            # clear context queue
-            self._ctx_queue.get(timeout=0.1)
-        except Empty:
-            pass
-
         # serialize and send context
         ctx_bytes = dill.dumps(ctx)
-        self._ctx_queue.put_nowait(ctx_bytes)
+        self._send_ctx_bytes(ctx_bytes)
 
         if blocking:
             # wait for feedback from worker
@@ -291,6 +330,41 @@ class Worker(mp.Process):
         else:
             self._logger.debug(f"Sent new context to worker {self._rank} in non-blocking mode.")
             return True
+
+    def _send_ctx_bytes(self, ctx_bytes: bytes, timeout: float = _CTX_SEND_TIMEOUT) -> None:
+        """Replace whatever context is queued for the worker with `ctx_bytes`.
+
+        The queue holds at most one pending context, so a stale one is dropped first.
+        Draining and then calling `put_nowait` is not enough on its own: a
+        `multiprocessing.Queue` is fed by a background thread, so a successful `get()`
+        does not free the slot synchronously and an item already in flight can arrive
+        between the two calls. `put_nowait` then raises `Full`, which used to escape into
+        the controller's message loop and take it down - leaving the workers waiting for a
+        context that never came, so they never joined and the run hung.
+
+        Retry within a deadline instead, and treat exhaustion as a dropped context rather
+        than a fatal error: the balancer sends these continuously, so the next one will
+        carry the same information.
+        """
+        deadline = time.monotonic() + timeout
+        while True:
+            try:
+                self._ctx_queue.get_nowait()
+            except Empty:
+                pass
+
+            try:
+                self._ctx_queue.put_nowait(ctx_bytes)
+                return
+            except Full:
+                if time.monotonic() >= deadline:
+                    self._logger.warning(
+                        f"Could not hand a new context to worker {self._rank} within "
+                        f"{timeout}s; the worker is not consuming its context queue. "
+                        f"Dropping this context."
+                    )
+                    return
+                time.sleep(_CTX_SEND_RETRY_INTERVAL)
 
     def _send_msg(self, msg_type: MessageType, payload: None | Any = None) -> None:
         """Send a message from the worker to the manager process.
@@ -966,10 +1040,10 @@ class DynamicMultiprocessingRunner(BaseRunner):
 
         # TODO: rethink which ex_iterable items to include
         #       maybe just all of them, i.e. all those that have the ex_iterable attribute
-        if isinstance(ex_iterable, _SEPARABLE_EX_ITERABLES):
+        if _is_separable(ex_iterable):
             # collect all processing steps to separate off
             transform = ExamplesIterablePipeline([ex_iterable])
-            while isinstance(transform.src_iterable, _SEPARABLE_EX_ITERABLES):
+            while _is_separable(transform.src_iterable):
                 transform.insert(0, transform.src_iterable)
 
             self._logger.info(

--- a/tests/crane/core/runners/test_multi_process_runner.py
+++ b/tests/crane/core/runners/test_multi_process_runner.py
@@ -1,10 +1,13 @@
 import json
 import multiprocessing as mp
+from queue import Full
 from unittest.mock import MagicMock, call, patch
 
 import datasets
+import dill
 import pytest
 from datasets import Dataset
+from datasets.iterable_dataset import SelectColumnsIterable
 
 from crane.core.callbacks.base import CallbackManager
 from crane.core.runners.base import WorkerProcessingStage, WorkerRole
@@ -96,6 +99,51 @@ class TestWorker:
 
         # check if new context was applied
         assert worker._ctx == ctx
+
+    def test_send_ctx_survives_full_queue(self, worker):
+        # A multiprocessing queue is fed by a background thread, so an item can land in
+        # the slot between the drain and the put. That used to raise `Full` out of
+        # `send_ctx` and kill the controller's message loop, leaving workers waiting for
+        # a context that never arrived - the run then hung instead of finishing.
+        ctx = WorkerContext(
+            role=WorkerRole.STANDALONE,
+            data_stream="STREAM",
+            data_transform="TRANSFORM",
+            data_finalizer="FINALIZE",
+            stop=False,
+        )
+        worker._recv_ctx_resp_conn.recv = MagicMock()
+
+        real_put_nowait = worker._ctx_queue.put_nowait
+        calls = []
+
+        def flaky_put_nowait(item):
+            calls.append(item)
+            if len(calls) == 1:
+                raise Full()
+            real_put_nowait(item)
+
+        worker._ctx_queue.put_nowait = flaky_put_nowait
+        worker.send_ctx(ctx)
+
+        assert len(calls) == 2, "should have retried after the queue reported itself full"
+        assert dill.loads(worker._ctx_queue.get(timeout=1.0)) == ctx
+
+    def test_send_ctx_gives_up_without_raising(self, worker):
+        # A worker that never drains its queue must not take the controller down with it.
+        ctx = WorkerContext(
+            role=WorkerRole.STANDALONE,
+            data_stream="STREAM",
+            data_transform="TRANSFORM",
+            data_finalizer="FINALIZE",
+            stop=False,
+        )
+        worker._recv_ctx_resp_conn.recv = MagicMock()
+        worker._ctx_queue.put_nowait = MagicMock(side_effect=Full())
+
+        worker.send_ctx(ctx)  # must return rather than raise
+
+        assert worker._ctx_queue.put_nowait.call_count > 1
 
     @patch("crane.core.runners.multi_process_runner.set_worker_info")
     def test_run(self, mock_set_worker_info, worker, data_stream, transform):
@@ -250,6 +298,14 @@ def _plus_one_fn(x):
     return {"obj": x["obj"] + 1}
 
 
+def _iter_chain(ex_iterable):
+    """Yield an examples-iterable and every step beneath it."""
+    node = ex_iterable
+    while node is not None:
+        yield node
+        node = getattr(node, "ex_iterable", None)
+
+
 class TestDynamicMultiprocessingRunner:
     @pytest.fixture
     def ds(self):
@@ -308,6 +364,45 @@ class TestDynamicMultiprocessingRunner:
             raise KeyboardInterrupt()
 
         runner.run(ds, raise_exc)
+
+    @pytest.mark.parametrize("num_shards", [2, 3])
+    def test_run_with_map_removing_columns(self, num_shards, runner):
+        # `.map(remove_columns=...)` puts a `SelectColumnsIterable` between the maps. If
+        # the split stops there, every step below stays with the source and the run fails
+        # sharding an arrow-formatted map that is still attached to it.
+        samples = {"obj": [i for i in range(20)], "drop_me": ["x"] * 20}
+        ds = Dataset.from_dict(samples).to_iterable_dataset(num_shards)
+        ds = ds.map(_plus_one_fn, remove_columns=["drop_me"]).map(_double_fn)
+
+        fn = SharedMock()
+        runner.run(ds, fn)
+        fn.assert_has_calls([call(sample) for sample in ds], same_order=False)
+
+    def test_prepare_dataset_separates_projection_above_processing(self, runner):
+        # a projection with real work beneath it must be separated, otherwise that work
+        # is stranded in the producers
+        ds = Dataset.from_dict({"obj": list(range(8)), "drop_me": ["x"] * 8})
+        ds = ds.to_iterable_dataset(2).map(_plus_one_fn, remove_columns=["drop_me"])
+
+        src_ex_it, pipeline = runner._prepare_dataset(ds)
+
+        assert not any(
+            isinstance(step, SelectColumnsIterable) for step in _iter_chain(src_ex_it)
+        ), "projection should have been separated off the source"
+        assert [v for _, v in pipeline(src_ex_it)] == list(ds)
+
+    def test_prepare_dataset_keeps_projection_directly_on_source(self, runner):
+        # nothing separable beneath it, so keeping it in the producer is what limits how
+        # many columns travel through the queue
+        ds = Dataset.from_dict({"obj": list(range(8)), "drop_me": ["x"] * 8})
+        ds = ds.to_iterable_dataset(2).select_columns(["obj"])
+
+        src_ex_it, pipeline = runner._prepare_dataset(ds)
+
+        assert any(
+            isinstance(step, SelectColumnsIterable) for step in _iter_chain(src_ex_it)
+        ), "a projection sitting directly on the source should stay with it"
+        assert [v for _, v in pipeline(src_ex_it)] == list(ds)
 
     @pytest.mark.parametrize("nested", [0, 1, 2])
     def test_prepare_dataset(self, nested, runner, ds):


### PR DESCRIPTION
Two problems that together made DynamicMultiprocessingRunner unusable for a pipeline built by TRL's SFT dataset preparation.

`.map(remove_columns=...)` inserts a `SelectColumnsIterable` mid-chain, and `_prepare_dataset` stopped its walk there. Every step below it then stayed with the data source, so real work ran in the producers and sharding a source that still carried an arrow-formatted map failed outright with "doesn't implement iter_arrow()". Projections are now separated - but only when there is something separable beneath them: one sitting directly on the source is pure projection, and keeping it in the producer means fewer columns travel through the queue.

`Worker.send_ctx` drained its single-slot queue and then called `put_nowait`. A `multiprocessing.Queue` is fed by a background thread, so a successful `get()` does not free the slot synchronously and an item in flight can arrive between the two calls; `put_nowait` then raised `Full` out of the controller's message loop. Workers were left waiting for a context that never came, never joined, and the run hung until `assert_all_workers_joined` tripped. Delivery is now retried within a short deadline and a dropped context is logged rather than fatal - the balancer re-sends continuously.

Both were found preparing a 7.7M-document corpus with TRL, with these the run completes and the output loads with `load_from_disk`.