### PR TITLE
fix(writers)!: make write_batch_size the size the writer actually gets

### DIFF
--- a/src/crane/core/batching.py
+++ b/src/crane/core/batching.py
@@ -1,0 +1,140 @@
+"""Regrouping the batches a pipeline delivers into the batches a writer was asked for.
+
+The batches flowing through a pipeline are sized for throughput - small enough to keep
+memory flat and workers fed - and rebatched along the way by every :func:`map` the caller
+applied. What a writer is handed is therefore whatever survived that, not what it asked for,
+and a writer that passes it straight to disk lets the plumbing decide the layout of the file.
+
+The asymmetry is what makes this worth guarding against. Writing a batch per row costs the
+writer almost nothing, so nothing pushes back where the mistake is made, while formats that
+carry per-batch metadata make every reader pay for it afterwards - on a real corpus here,
+written a row at a time, the difference was 125 seconds to open the dataset against 0.09.
+
+Both batch formats a writer can receive are handled, so a writer of either kind gets the
+size it asked for without knowing this happened.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, TypeAlias
+
+import pyarrow as pa
+
+BatchT: TypeAlias = pa.Table | dict[str, list[Any]]
+"""A batch, in either of the formats a writer receives."""
+
+
+def num_rows(batch: BatchT) -> int:
+    """Count the rows in a batch of either format.
+
+    Args:
+        batch (BatchT): The batch to measure.
+
+    Returns:
+        int: The number of rows.
+    """
+    if isinstance(batch, pa.Table):
+        return batch.num_rows
+
+    return len(next(iter(batch.values()), []))
+
+
+def concat(batches: list[BatchT]) -> BatchT:
+    """Join batches of either format into one.
+
+    Args:
+        batches (list[BatchT]): The batches to join, all of the same format and columns.
+
+    Returns:
+        BatchT: The batches as one.
+    """
+    if isinstance(batches[0], pa.Table):
+        # `combine_chunks` is what makes the result one batch rather than one per table
+        # joined: a writer emits per chunk, so concatenating alone would keep them separate
+        # and the regrouping would have achieved nothing.
+        return pa.concat_tables(batches).combine_chunks()
+
+    return {key: [row for batch in batches for row in batch[key]] for key in batches[0]}
+
+
+def slice_batch(batch: BatchT, offset: int, length: None | int = None) -> BatchT:
+    """Take a range of rows out of a batch of either format.
+
+    Args:
+        batch (BatchT): The batch to slice.
+        offset (int): The first row to take.
+        length (None | int): How many rows to take, or None for all that remain.
+
+    Returns:
+        BatchT: The requested rows.
+    """
+    if isinstance(batch, pa.Table):
+        return batch.slice(offset) if length is None else batch.slice(offset, length)
+
+    end = None if length is None else offset + length
+    return {key: values[offset:end] for key, values in batch.items()}
+
+
+@dataclass
+class BatchBuffer(object):
+    """Regroups batches into a fixed size, whatever size they arrive in.
+
+    Emits batches of exactly :attr:`size` and keeps the remainder, rather than handing back
+    whatever has piled up. Flushing the pile would leave the result depending on the arrival
+    sizes after all - batches of 256 gathered to a threshold of 500 give 512, batches of 8
+    give 504 - which is the coupling this exists to break.
+
+    One buffer belongs to one open shard: :func:`take` is what a shard's finalization calls,
+    and a shard closed without it loses every row still waiting.
+    """
+
+    size: int
+    """Rows in each batch handed back by :func:`add`."""
+
+    _pending: list[BatchT] = field(default_factory=list)
+    _rows: int = 0
+
+    def add(self, batch: BatchT) -> list[BatchT]:
+        """Take a batch, and hand back any full batches it completes.
+
+        Returns a list because one arrival can complete several: a caller handing over more
+        rows than :attr:`size` should not have to call again to get them all out.
+
+        Args:
+            batch (BatchT): The batch to take.
+
+        Returns:
+            list[BatchT]: Batches of exactly :attr:`size` rows, empty while there are still
+            too few.
+        """
+        rows = num_rows(batch)
+        if rows:
+            self._pending.append(batch)
+            self._rows += rows
+
+        full = []
+        while self._rows >= self.size:
+            joined = concat(self._pending)
+            full.append(slice_batch(joined, 0, self.size))
+
+            rest = slice_batch(joined, self.size)
+            self._rows = num_rows(rest)
+            self._pending = [rest] if self._rows else []
+
+        return full
+
+    def take(self) -> None | BatchT:
+        """Hand back whatever is left, however little, and empty the buffer.
+
+        Args:
+            None
+
+        Returns:
+            None | BatchT: The remaining rows as one batch, or None if there are none.
+        """
+        if not self._pending:
+            return None
+
+        joined = concat(self._pending)
+        self._pending = []
+        self._rows = 0
+        return joined

--- a/src/crane/core/writer.py
+++ b/src/crane/core/writer.py
@@ -28,11 +28,13 @@ from datasets.iterable_dataset import (
     TakeExamplesIterable,
 )
 
+from .batching import BatchBuffer
 from .callbacks.base import Callback
 from .consumer import DatasetConsumer
 from .runners.base import FailurePolicy
 from .sharding import ShardingController, ShardingStrategy
 from .utils import Compose, FormatType, RunAll, chdir
+from .worker import get_worker_info
 
 logger = logging.getLogger(__name__)
 
@@ -115,8 +117,20 @@ class BaseDatasetWriter(ABC):
                 to the number of CPU cores.
             prefetch_factor (int): Number of samples to prefetch for improved
                 performance. Defaults to 8.
-            write_batch_size (int): The number of samples to write in a single batch.
-                Defaults to 32.
+            write_batch_size (int): The number of samples handed to the writer in one call,
+                and so the unit the output is laid out in. Batches are regrouped to exactly
+                this size before they reach the writer, whatever size the pipeline delivered:
+                a pipeline's batches are sized for throughput and rebatched by every
+                :func:`map` along the way, so without that the layout of the output would be
+                an accident of the pipeline. Writing a batch per sample costs the writer
+                nothing and costs every reader afterwards - a dataset written that way took
+                125 seconds to open rather than 0.09. Defaults to 256.
+
+                Interacts with :code:`max_shard_size`: a shard rolls over on what has reached
+                the file, and nothing reaches it until a batch is full, so a shard can
+                overshoot by up to one batch and a dataset smaller than one batch is written
+                as a single shard. The rows held are held in memory, so a very wide row wants
+                a smaller value.
             tqdm_update_interval (float): The interval in seconds at which the tqdm
                 progress bar updates. Default is 0.1.
             disable_tqdm (bool): Whether to disable the tqdm progress bar. Default is
@@ -149,6 +163,63 @@ class BaseDatasetWriter(ABC):
         # callbacks
         self._callbacks = callbacks
         self._failure_policy = failure_policy
+
+    def _open_shard(self, shard_id: int, info: datasets.DatasetInfo) -> None:
+        """Start a shard, and the buffer that regroups what is written to it.
+
+        The buffer belongs to the worker rather than to the writer, alongside the shard's
+        own file handle. A worker receives its own copy of the writer for writing and
+        another for finalizing - they travel to it separately - so a buffer held on the
+        writer would be filled by one copy and flushed by the other, which is to say never.
+
+        Args:
+            shard_id (int): The id of the shard being opened.
+            info (datasets.DatasetInfo): Information about the dataset being written.
+        """
+        worker = get_worker_info()
+        worker.ctx.buffer = BatchBuffer(self._write_batch_size)
+        worker.ctx.write_fn = None
+        self.initialize_shard(shard_id, info)
+
+    def _close_shard(self, info: datasets.DatasetInfo) -> None:
+        """Write whatever the buffer still holds, then let the writer close the shard.
+
+        The flush has to happen here rather than at the end of the run: a shard rolls over
+        while there is still data to come, and rows held past that point would be written
+        into the shard that follows - or, for the last shard, into nothing at all.
+
+        Args:
+            info (datasets.DatasetInfo): Information about the dataset being written.
+        """
+        worker = get_worker_info()
+        remainder = worker.ctx.buffer.take()
+        if (remainder is not None) and (worker.ctx.write_fn is not None):
+            worker.ctx.write_fn(remainder)
+
+        self.finalize_shard(info)
+
+    def _write_batches(self, write_fn: Callable[[Any], int], batch: Any) -> int:
+        """Hand the writer batches of the size it asked for, whatever size arrived.
+
+        A pipeline's batches are sized for throughput and rebatched by every :func:`map`
+        along the way, so what arrives here is not what :code:`write_batch_size` asked for.
+        Passing it straight through makes that accident the layout of the file - a batch per
+        row, if that is what the pipeline happened to produce - which costs nothing to write
+        and is expensive for every reader of the file afterwards.
+
+        Args:
+            write_fn (Callable[[Any], int]): The writer's own batch write, bound by
+                :func:`_get_write_fn`.
+            batch (Any): The batch that arrived.
+
+        Returns:
+            int: The number of bytes written, which is zero while the buffer is still short
+            of a full batch.
+        """
+        # Kept for `_close_shard`, which flushes without having a batch of its own to pass.
+        worker = get_worker_info()
+        worker.ctx.write_fn = write_fn
+        return sum(write_fn(full) for full in worker.ctx.buffer.add(batch))
 
     def _write_info(self, ds: datasets.IterableDataset) -> None:
         """Write dataset information to a JSON file in the save directory.
@@ -273,8 +344,8 @@ class BaseDatasetWriter(ABC):
             sharding_strategy=self._sharding_strategy,
             max_shard_size=self._max_shard_size,
             sample_size_key=self._sample_size_key,
-            initialize_shard=partial(self.initialize_shard, info=ds.info),
-            finalize_shard=partial(self.finalize_shard, info=ds.info),
+            initialize_shard=partial(self._open_shard, info=ds.info),
+            finalize_shard=partial(self._close_shard, info=ds.info),
             formatting=formatting,
         )
 
@@ -283,7 +354,7 @@ class BaseDatasetWriter(ABC):
         # shard but never rolls over.
         write_fn = Compose(
             sharding_controller.update,
-            write_fn,
+            partial(self._write_batches, write_fn),
             sharding_controller.callback,
         )
 

--- a/tests/crane/core/test_batching.py
+++ b/tests/crane/core/test_batching.py
@@ -1,0 +1,109 @@
+import pyarrow as pa
+import pytest
+
+from crane.core.batching import BatchBuffer
+
+
+def table(rows: int) -> pa.Table:
+    return pa.table({"x": list(range(rows))})
+
+
+def columns(rows: int) -> dict:
+    """The other format a writer receives: a dictionary of columns."""
+    return {"x": list(range(rows))}
+
+
+class TestBatchBuffer:
+    def test_holds_batches_until_there_are_enough_rows(self):
+        buffer = BatchBuffer(size=10)
+
+        assert buffer.add(table(4)) == []
+        assert buffer.add(table(4)) == []
+
+    @pytest.mark.parametrize("arriving", [1, 3, 8, 250])
+    def test_what_comes_back_is_the_asked_for_size_whatever_arrives(self, arriving):
+        # the whole point: flushing the pile instead would give 504 for batches of 8 and
+        # 512 for batches of 256, so the layout would still depend on the arrival size
+        buffer = BatchBuffer(size=500)
+        sizes = []
+
+        for _ in range(1000 // arriving):
+            sizes += [t.num_rows for t in buffer.add(table(arriving))]
+
+        assert set(sizes) <= {500}
+
+    def test_each_batch_handed_back_is_a_single_record_batch(self):
+        # concatenating alone would leave one chunk per batch held, and a writer emits a
+        # record batch per chunk
+        buffer = BatchBuffer(size=3)
+        buffer.add(table(1))
+        buffer.add(table(1))
+
+        (out,) = buffer.add(table(1))
+
+        assert len(out.to_batches()) == 1
+
+    def test_one_arrival_can_complete_several_batches(self):
+        buffer = BatchBuffer(size=10)
+
+        out = buffer.add(table(35))
+
+        assert [t.num_rows for t in out] == [10, 10, 10]
+
+    def test_taking_empties_the_buffer(self):
+        buffer = BatchBuffer(size=10)
+        buffer.add(table(4))
+
+        assert buffer.take().num_rows == 4
+        assert buffer.take() is None
+
+    def test_taking_an_empty_buffer_is_not_an_error(self):
+        assert BatchBuffer(size=10).take() is None
+
+    def test_rows_are_never_lost_across_a_run_of_batches(self):
+        buffer = BatchBuffer(size=7)
+        written = sum(t.num_rows for _ in range(20) for t in buffer.add(table(3)))
+
+        remainder = buffer.take()
+
+        assert written + (remainder.num_rows if remainder is not None else 0) == 60
+
+    def test_a_size_of_one_writes_every_row_through(self):
+        buffer = BatchBuffer(size=1)
+
+        assert [t.num_rows for t in buffer.add(table(4))] == [1, 1, 1, 1]
+
+
+class TestColumnBatches:
+    """The other format a writer receives, which the JSON writer uses."""
+
+    def test_columns_are_regrouped_to_the_asked_for_size(self):
+        buffer = BatchBuffer(size=10)
+        sizes = []
+
+        for _ in range(30):
+            sizes += [len(b["x"]) for b in buffer.add(columns(1))]
+
+        assert sizes == [10, 10, 10]
+
+    def test_a_remainder_comes_back_whole(self):
+        buffer = BatchBuffer(size=10)
+        buffer.add(columns(4))
+
+        assert len(buffer.take()["x"]) == 4
+
+    def test_rows_keep_their_order_and_values(self):
+        buffer = BatchBuffer(size=3)
+        out = []
+
+        for start in (0, 3, 6):
+            out += buffer.add({"x": [start, start + 1, start + 2]})
+
+        assert [b["x"] for b in out] == [[0, 1, 2], [3, 4, 5], [6, 7, 8]]
+
+    def test_an_empty_batch_changes_nothing(self):
+        # a map that filters everything out of a batch still reaches the writer
+        buffer = BatchBuffer(size=3)
+
+        assert buffer.add({"x": []}) == []
+        assert buffer.take() is None

--- a/tests/crane/core/test_writer.py
+++ b/tests/crane/core/test_writer.py
@@ -1,12 +1,16 @@
 import json
 import os
+from copy import deepcopy
 from unittest.mock import ANY, MagicMock, call, patch
 
 import datasets
+import pyarrow as pa
 import pytest
 from datasets import Dataset, IterableDataset, IterableDatasetDict
 
+from crane.core.batching import BatchBuffer
 from crane.core.utils import chdir
+from crane.core.worker import get_worker_info, reset_worker_info, set_worker_info
 from crane.core.writer import BaseDatasetWriter
 
 
@@ -121,14 +125,27 @@ class TestBaseDatasetWriter:
             init = consumer_mock.mock_calls[0].kwargs["on_start"]
             finalize = consumer_mock.mock_calls[0].kwargs["on_finish"]
 
-            # apply function
-            mock_batch = MagicMock()
+            # Apply the function. A real batch rather than a mock: the writer regroups what
+            # it is handed into batches of `write_batch_size`, so it has to be able to count
+            # the rows. One row against a size of one passes straight through.
+            #
+            # Inside a worker, because that is where the write path runs and where the
+            # buffer lives - the sharding controller is mocked here, so the shard that would
+            # have created it never opens.
+            reset_worker_info()
+            set_worker_info(rank=0, num_workers=1, seed=None)
+            get_worker_info().ctx.buffer = BatchBuffer(1)
+            get_worker_info().ctx.write_fn = None
+            mock_batch = {"obj": [0]}
+            sharding_mock().callback.return_value = mock_batch
+            sharding_mock.reset_mock(return_value=False)
+            sharding_mock().callback.return_value = mock_batch
             fn(mock_batch)
             # make sure that the callback is called first, then the write sample
             # and finally the update function. The callback also opens the shard for the
             # batch, so it runs for every strategy, including NONE.
             sharding_mock().callback.assert_called_once_with(mock_batch)
-            writer.write_batch_py.assert_called_once_with(sharding_mock().callback())
+            writer.write_batch_py.assert_called_once_with(mock_batch)
             sharding_mock().update(writer.write_batch_py())
 
             # starting a worker must not open a shard - that only happens once a batch
@@ -221,3 +238,57 @@ class TestBaseDatasetWriter:
                 state = json.load(f)
 
         assert [entry["filename"] for entry in state["_data_files"]] == shards
+
+
+class TestShardBufferOwnership:
+    """Where the batch buffer lives, which is not a detail.
+
+    A worker receives one copy of the writer for writing and another for finalizing - they
+    are pickled separately, the write path through the runner's setup and the finalize path
+    through its worker callbacks. A buffer held on the writer is therefore filled by one copy
+    and flushed by the other, which is to say never: every row still held when a shard closes
+    is dropped, silently, and a dataset smaller than one batch comes out empty.
+    """
+
+    @pytest.fixture
+    def writer_type(self):
+        class MockDatasetWriter(BaseDatasetWriter):
+            SHARD_FILE_EXTENSION = "mock"
+            written = []
+
+            def write_batch_arrow(self, batch):
+                type(self).written.append(batch)
+                return 1
+
+            initialize_shard = MagicMock()
+            finalize_shard = MagicMock()
+
+        MockDatasetWriter.written = []
+        return MockDatasetWriter
+
+    @pytest.fixture(autouse=True)
+    def in_a_worker(self):
+        reset_worker_info()
+        set_worker_info(rank=0, num_workers=1, seed=None)
+        yield
+        reset_worker_info()
+
+    def test_a_separate_copy_can_flush_what_another_buffered(self, writer_type, tmp_path):
+        writer = writer_type(save_dir=str(tmp_path), write_batch_size=1000)
+        # exactly what a worker is handed: two copies that never see each other again
+        finalizing_copy = deepcopy(writer)
+
+        writer._open_shard(0, info=MagicMock())
+        writer._write_batches(writer.write_batch_arrow, pa.table({"x": list(range(10))}))
+        assert writer_type.written == [], "nothing should be written before a batch is full"
+
+        finalizing_copy._close_shard(info=MagicMock())
+
+        assert [t.num_rows for t in writer_type.written] == [10]
+
+    def test_the_buffer_is_not_kept_on_the_writer(self, writer_type, tmp_path):
+        writer = writer_type(save_dir=str(tmp_path), write_batch_size=1000)
+        writer._open_shard(0, info=MagicMock())
+
+        assert not hasattr(writer, "_buffer")
+        assert get_worker_info().ctx.buffer is not None

--- a/tests/crane/test_arrow.py
+++ b/tests/crane/test_arrow.py
@@ -1,3 +1,8 @@
+import os
+
+import datasets
+import pyarrow as pa
+import pytest
 from datasets import Dataset, DatasetDict, load_from_disk
 
 from crane import ArrowDatasetWriter
@@ -35,3 +40,64 @@ class TestArrowDatasetWriter_DatasetDict(BaseTestDatasetWriter):
             # compare to source dataset
             for actual, expected in zip(actual_ds[split], ds):
                 assert actual == expected
+
+
+class TestRecordBatchSize:
+    """The file's layout must not be decided by the pipeline's batch size.
+
+    Written straight through, a pipeline batch of one row becomes a record batch of one row.
+    Arrow stream files carry no index, so every reader then parses one header per row: a real
+    corpus here held 831,232 record batches in a 5 GB shard and took 129s to open.
+    """
+
+    @staticmethod
+    def _batches(save_dir: str) -> list[int]:
+        shard = next(f for f in os.listdir(save_dir) if f.endswith(".arrow"))
+        with pa.memory_map(os.path.join(save_dir, shard), "rb") as source:
+            return [batch.num_rows for batch in pa.ipc.open_stream(source)]
+
+    @pytest.fixture
+    def ds(self):
+        return Dataset.from_dict({"x": list(range(1000))}).to_iterable_dataset(num_shards=1)
+
+    @pytest.mark.parametrize("prefetch", [1, 8, 256])
+    def test_the_pipeline_batch_size_does_not_decide_the_file_layout(self, ds, tmp_path, prefetch):
+        out = str(tmp_path / f"out-{prefetch}")
+        ArrowDatasetWriter(
+            out,
+            write_batch_size=500,
+            prefetch_factor=prefetch,
+            num_proc=1,
+            disable_tqdm=True,
+        ).write(ds)
+
+        assert self._batches(out) == [500, 500]
+
+    def test_every_row_survives_being_buffered(self, ds, tmp_path):
+        # the failure this guards against loses rows silently: nothing downstream knows a
+        # buffered row existed
+        out = str(tmp_path / "out")
+        ArrowDatasetWriter(out, write_batch_size=512, num_proc=1, disable_tqdm=True).write(ds)
+
+        assert sum(self._batches(out)) == 1000
+        assert sorted(datasets.load_from_disk(out)["x"]) == list(range(1000))
+
+    def test_a_remainder_smaller_than_the_threshold_is_still_written(self, ds, tmp_path):
+        # 1000 rows at 300 per batch leaves 100 that only `finalize_shard` will write
+        out = str(tmp_path / "out")
+        ArrowDatasetWriter(out, write_batch_size=300, num_proc=1, disable_tqdm=True).write(ds)
+
+        assert self._batches(out) == [300, 300, 300, 100]
+
+    def test_one_row_per_batch_is_still_available(self, ds, tmp_path):
+        # the old behaviour, for a caller who wants it
+        out = str(tmp_path / "out")
+        ArrowDatasetWriter(
+            out,
+            write_batch_size=1,
+            prefetch_factor=1,
+            num_proc=1,
+            disable_tqdm=True,
+        ).write(ds)
+
+        assert len(self._batches(out)) == 1000

--- a/tests/crane/test_parquet.py
+++ b/tests/crane/test_parquet.py
@@ -3,6 +3,7 @@ import os
 
 import pyarrow.dataset as pds
 import pyarrow.parquet as pq
+import pytest
 from datasets import Dataset, DatasetDict, load_dataset
 
 from crane import ParquetDatasetWriter
@@ -76,7 +77,9 @@ class TestParquetDatasetWriter_RowGroupSize(BaseTestDatasetWriter):
 class TestParquetDatasetWriter_Metadata(BaseTestDatasetWriter):
     dataset = Dataset.from_dict({"obj": list(range(100))})
     writer_type = ParquetDatasetWriter
-    # small shards, so there is more than one for `_metadata` to summarise
+    # Small shards, so there is more than one for `_metadata` to summarise. `write_batch_size`
+    # is what makes that possible: a shard rolls over on what has reached the file, and
+    # nothing reaches it until a batch is full.
     writer_args = {"max_shard_size": 1024, "write_batch_size": 10}
 
     def execute_test(self) -> None:
@@ -135,3 +138,44 @@ class TestParquetDatasetWriter_MetadataForDatasetDict(BaseTestDatasetWriter):
         for split, ds in type(self).dataset.items():
             metadata = pq.read_metadata(os.path.join(split, "_metadata"))
             assert metadata.num_rows == len(ds)
+
+
+class TestRowGroupSize:
+    """Row groups are the unit a reader skips and the unit compression works over.
+
+    `ParquetWriter.write_table` emits at least one row group per call, so writing pipeline
+    batches straight through gave a row group per batch - 4000 of them for 4000 rows when
+    the pipeline delivered one row at a time.
+    """
+
+    @staticmethod
+    def _row_groups(save_dir: str) -> int:
+        shard = next(f for f in os.listdir(save_dir) if f.endswith(".parquet"))
+        return pq.ParquetFile(os.path.join(save_dir, shard)).metadata.num_row_groups
+
+    @pytest.fixture
+    def ds(self):
+        return Dataset.from_dict({"x": list(range(1000))}).to_iterable_dataset(num_shards=1)
+
+    @pytest.mark.parametrize("prefetch", [1, 8, 256])
+    def test_the_pipeline_batch_size_does_not_decide_the_file_layout(self, ds, tmp_path, prefetch):
+        out = str(tmp_path / f"out-{prefetch}")
+        ParquetDatasetWriter(
+            out,
+            write_batch_size=500,
+            prefetch_factor=prefetch,
+            num_proc=1,
+            disable_tqdm=True,
+            write_metadata=False,
+        ).write(ds)
+
+        assert self._row_groups(out) == 2
+
+    def test_every_row_survives_being_buffered(self, ds, tmp_path):
+        out = str(tmp_path / "out")
+        ParquetDatasetWriter(
+            out, write_batch_size=512, num_proc=1, disable_tqdm=True, write_metadata=False
+        ).write(ds)
+
+        loaded = load_dataset("parquet", data_files=os.path.join(out, "*.parquet"))["train"]
+        assert sorted(loaded["x"]) == list(range(1000))


### PR DESCRIPTION
A batch went to disk in whatever size the pipeline delivered it, so the layout of the file was an accident of the plumbing. Written one row at a time, a file ends up with one record batch per row, one Parquet row group per row, one line write per row.

That is exactly what a 47 GB corpus here held: 7,769,968 record batches for 7,769,968 rows. Arrow stream files carry no index, so opening one means parsing the header of every batch in it. Rewritten at 1024 rows per batch:

    record batches   7,769,968  ->  7,590
    size                46.8 GB ->  39.1 GB
    load_from_disk       125.27s ->  0.09s

Same 7,769,968 rows. The 7.7 GB was per-batch metadata, and the 125 seconds was paid by everything that ever opened the corpus. Unpickling it cost 93 seconds, once per shard, which is how a distributed run came to spend 46 minutes per job deserializing its payload.

The asymmetry is the trap: writing a batch per row costs the writer nothing, so nothing pushes back where the mistake is made, and the cost lands on every reader afterwards.

`write_batch_size` was already documented as "the number of samples to write in a single batch" and did not hold: the runner turns it into a `datasets` map batch size, which upstream rebatching overrides, as the TODO above it has long said. It now does what it says, by being enforced in the write path rather than requested of the pipeline - `BatchBuffer` regroups into batches of exactly that size before they reach the writer. Exactly, not at least: handing over whatever had piled up would leave the result depending on the arrival size anyway, giving 504 for batches of 8 and 512 for batches of 256.

In the base writer, so every writer gets it, both batch formats are handled, so the JSON writer benefits alongside the Arrow and Parquet ones, and none of them needed changing. The buffer belongs to an open shard and is flushed when that shard is finalized: a shard rolls over while data is still coming, and rows held across that boundary would land in the next shard, or in nothing at all.

BREAKING CHANGE: a shard can overshoot `max_shard_size` by up to one batch, since a shard rolls over on what has reached the file and nothing reaches it until a batch is full. A dataset smaller than one batch is written as a single shard.